### PR TITLE
Documentation and error handling for 'tree.order' option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ Shared with Dan/orchard2_plot_survey_updated.html.zip
 Shared with Dan/orchard2_plot_survey_updated.html
 Shared with Dan/orachRd2_V13_clean.pdf
 
+R/caterpillars_MLJ.R

--- a/R/orchard_plot.R
+++ b/R/orchard_plot.R
@@ -15,6 +15,7 @@
 #' @param g If \code{TRUE}, it displays g (number of grouping levels for each level of the moderator) on the plot.
 #' @param transfm If set to \code{"tanh"}, a tanh transformation will be applied to effect sizes, converting Zr to a correlation or pulling in extreme values for other effect sizes (lnRR, lnCVR, SMD). Defaults to \code{"none"}.
 #' @param condition.lab Label for the condition being marginalized over.
+#' @param tree.order Order in which to plot the groups of the moderator when it is a categorical one. Should be a vector of equal length to number of groups in the categorical moderator, in the desired order (bottom to top, or left to right for flipped orchard plot) 
 #' @param trunk.size Size of the mean, or central point.
 #' @param branch.size Size of the confidence intervals.
 #' @param twig.size Size of the prediction intervals.
@@ -97,6 +98,16 @@ orchard_plot <- function(object, mod = "1", group, xlab, N = NULL,
 
   data_trim$scale <- (1/sqrt(data_trim[,"vi"]))
 	legend <- "Precision (1/SE)"
+	
+	#if length of tree order does not match number of categories in categorical moderator, then stop function and throw an error
+	if(length(tree.order)!=levels(data_trim[,'moderator']))){
+	  stop("Length of 'tree.order' does not equal number of categories in moderator")
+	}
+
+  #if tree.order, isn't equal to NULL, then reorder mod table according to custom order if there is one
+  if (!is.null(tree.order)){
+    mod_table <- mod_table %>% dplyr::arrange(factor(name, levels = tree.order))
+  }
 
 	if(is.null(N) == FALSE){
 	  data_trim$scale <- data_trim$N

--- a/R/orchard_plot.R
+++ b/R/orchard_plot.R
@@ -59,7 +59,7 @@
 
 orchard_plot <- function(object, mod = "1", group, xlab, N = NULL,
                          alpha = 0.5, angle = 90, cb = TRUE, k = TRUE, g = TRUE,
-                         trunk.size = 3, branch.size = 1.2, twig.size = 0.5,
+                         tree.order = NULL, trunk.size = 3, branch.size = 1.2, twig.size = 0.5,
                          transfm = c("none", "tanh"), condition.lab = "Condition",
                          legend.pos = c("bottom.right", "bottom.left",
                                         "top.right", "top.left",
@@ -99,13 +99,14 @@ orchard_plot <- function(object, mod = "1", group, xlab, N = NULL,
   data_trim$scale <- (1/sqrt(data_trim[,"vi"]))
 	legend <- "Precision (1/SE)"
 	
-	#if length of tree order does not match number of categories in categorical moderator, then stop function and throw an error
-	if(length(tree.order)!=levels(data_trim[,'moderator']))){
+	#if tree.order isn't equal to NULL, and length of tree order does not match number of categories in categorical moderator, then stop function and throw an error
+	if(!is.null(tree.order)&length(tree.order)!=nlevels(data_trim[,'moderator'])){
 	  stop("Length of 'tree.order' does not equal number of categories in moderator")
 	}
 
-  #if tree.order, isn't equal to NULL, then reorder mod table according to custom order if there is one
+  #if tree.order isn't equal to NULL but passes above check, then reorder mod table according to custom order if there is one
   if (!is.null(tree.order)){
+    data_trim$moderator<-factor(data_trim$moderator, levels = tree.order, labels = tree.order)
     mod_table <- mod_table %>% dplyr::arrange(factor(name, levels = tree.order))
   }
 

--- a/man/orchard_plot.Rd
+++ b/man/orchard_plot.Rd
@@ -15,6 +15,7 @@ orchard_plot(
   cb = TRUE,
   k = TRUE,
   g = TRUE,
+  tree.order = NULL,
   trunk.size = 3,
   branch.size = 1.2,
   twig.size = 0.5,
@@ -52,6 +53,8 @@ orchard_plot(
 \item{k}{If \code{TRUE}, it displays k (number of effect sizes) on the plot.}
 
 \item{g}{If \code{TRUE}, it displays g (number of grouping levels for each level of the moderator) on the plot.}
+
+\item{tree.order}{Order in which to plot the groups of the moderator when it is a categorical one. Should be a vector of equal length to number of groups in the categorical moderator, in the desired order (bottom to top, or left to right for flipped orchard plot)}
 
 \item{trunk.size}{Size of the mean, or central point.}
 


### PR DESCRIPTION
-Added @param with documentation
-Added error handler - if user specifies order of incorrect length, stops function and throws error