### PR TITLE
Fix ggplot deprecations in bubble_plot() and caterpillars()

### DIFF
--- a/R/bubble_plot.R
+++ b/R/bubble_plot.R
@@ -250,21 +250,16 @@ bubble_plot <- function(object, mod, group = NULL, xlab = "Moderator", ylab = "E
   }
 
   # adding legend
-  if(legend.pos == "bottom.right"){
-    plot <- plot + ggplot2::theme(legend.position.inside = c(1, 0), legend.justification = c(1, 0))
-  } else if ( legend.pos == "bottom.left") {
-    plot <- plot + ggplot2::theme(legend.position.inside = c(0, 0), legend.justification = c(0, 0))
-  } else if ( legend.pos == "top.right") {
-    plot <- plot + ggplot2::theme(legend.position.inside = c(1, 1), legend.justification = c(1, 1))
-  } else if (legend.pos == "top.left") {
-    plot <- plot + ggplot2::theme(legend.position.inside = c(0, 1), legend.justification = c(0, 1))
-  } else if (legend.pos == "top.out") {
-    plot <- plot + ggplot2::theme(legend.position="top")
-  } else if (legend.pos == "bottom.out") {
-    plot <- plot + ggplot2::theme(legend.position="bottom")
-  } else if (legend.pos == "none") {
-    plot <- plot + ggplot2::theme(legend.position="none")
-  }
+  plot <- switch(legend.pos,
+    "bottom.right" = plot + ggplot2::theme(legend.position = "inside", legend.justification = c(1, 0)),
+    "bottom.left"  = plot + ggplot2::theme(legend.position = "inside", legend.justification = c(0, 0)),
+    "top.right"    = plot + ggplot2::theme(legend.position = "inside", legend.justification = c(1, 1)),
+    "top.left"     = plot + ggplot2::theme(legend.position = "inside", legend.justification = c(0, 1)),
+    "top.out"      = plot + ggplot2::theme(legend.position = "top"),
+    "bottom.out"   = plot + ggplot2::theme(legend.position = "bottom"),
+    "none"         = plot + ggplot2::theme(legend.position = "none"),
+    plot
+  )
 
   # putting k and g in
   # c("top.right", "top.left", "bottom.right", "bottom.left","none")

--- a/R/bubble_plot.R
+++ b/R/bubble_plot.R
@@ -251,13 +251,13 @@ bubble_plot <- function(object, mod, group = NULL, xlab = "Moderator", ylab = "E
 
   # adding legend
   if(legend.pos == "bottom.right"){
-    plot <- plot + ggplot2::theme(legend.position= c(1, 0), legend.justification = c(1, 0))
+    plot <- plot + ggplot2::theme(legend.position.inside = c(1, 0), legend.justification = c(1, 0))
   } else if ( legend.pos == "bottom.left") {
-    plot <- plot + ggplot2::theme(legend.position= c(0, 0), legend.justification = c(0, 0))
+    plot <- plot + ggplot2::theme(legend.position.inside = c(0, 0), legend.justification = c(0, 0))
   } else if ( legend.pos == "top.right") {
-    plot <- plot + ggplot2::theme(legend.position= c(1, 1), legend.justification = c(1, 1))
+    plot <- plot + ggplot2::theme(legend.position.inside = c(1, 1), legend.justification = c(1, 1))
   } else if (legend.pos == "top.left") {
-    plot <- plot + ggplot2::theme(legend.position= c(0, 1), legend.justification = c(0, 1))
+    plot <- plot + ggplot2::theme(legend.position.inside = c(0, 1), legend.justification = c(0, 1))
   } else if (legend.pos == "top.out") {
     plot <- plot + ggplot2::theme(legend.position="top")
   } else if (legend.pos == "bottom.out") {

--- a/R/caterpillars.R
+++ b/R/caterpillars.R
@@ -129,7 +129,7 @@ caterpillars <- function(object, mod = "1",  group, xlab, overall = TRUE, transf
   plot <- ggplot2::ggplot(data = data, ggplot2::aes(x = yi, y = Y)) +
     # 95 % CI
     ggplot2::geom_errorbarh(ggplot2::aes(xmin = lower, xmax = upper),
-                            colour = colerrorbar, height = 0, show.legend = FALSE, size = 0.5, alpha = 0.6) +
+                            colour = colerrorbar, height = 0, show.legend = FALSE, linewidth = 0.5, alpha = 0.6) +
     ggplot2::geom_vline(xintercept = 0, linetype = 2, colour = "black", alpha = 0.5) +
     # creating dots for point estimates
     ggplot2::geom_point(colour = colpoint, size = 1) +


### PR DESCRIPTION
- bubble_plot(): the argument `legend.pos` previously used `ggplot2::theme(legend.position = c(0, 1) ...)`, but numeric values for `legend.position` were [deprecated in ggplot2 3.5.0](https://github.com/tidyverse/ggplot2/blob/b87a6e354d19fef05e6d20a24e7b62482ac80b5a/R/theme.R#L534C1-L541C4). Updated to `legend.position = inside` and use `legend.justification` to define the position inside the plot.

- caterpillars(): the `size` argument for `ggplot2::geom_errorbarh()` was also deprecated. Replaced with `linewidth`.

