### PR TITLE
Fix deprecated ggplot argument in orchard_plot()

### DIFF
--- a/R/orchard_plot.R
+++ b/R/orchard_plot.R
@@ -241,22 +241,17 @@ orchard_plot <- function(object, mod = "1", group, xlab, N = NULL,
 	}
 	 }
 
-	   # adding legend
-	 if(legend.pos == "bottom.right"){
-	   plot <- plot + ggplot2::theme(legend.position= c(1, 0), legend.justification = c(1, 0))
-	 } else if ( legend.pos == "bottom.left") {
-	   plot <- plot + ggplot2::theme(legend.position= c(0, 0), legend.justification = c(0, 0))
-	 } else if ( legend.pos == "top.right") {
-	   plot <- plot + ggplot2::theme(legend.position= c(1, 1), legend.justification = c(1, 1))
-	 } else if (legend.pos == "top.left") {
-	   plot <- plot + ggplot2::theme(legend.position= c(0, 1), legend.justification = c(0, 1))
-	 } else if (legend.pos == "top.out") {
-	   plot <- plot + ggplot2::theme(legend.position="top")
-	 } else if (legend.pos == "bottom.out") {
-	   plot <- plot + ggplot2::theme(legend.position="bottom")
-	 } else if (legend.pos == "none") {
-	   plot <- plot + ggplot2::theme(legend.position="none")
-	 }
+	 # Add legend
+	 plot <- switch(legend.pos,
+	                "bottom.right" = plot + ggplot2::theme(legend.position = "inside", legend.justification = c(1, 0)),
+	                "bottom.left"  = plot + ggplot2::theme(legend.position = "inside", legend.justification = c(0, 0)),
+	                "top.right"    = plot + ggplot2::theme(legend.position = "inside", legend.justification = c(1, 1)),
+	                "top.left"     = plot + ggplot2::theme(legend.position = "inside", legend.justification = c(0, 1)),
+	                "top.out"      = plot + ggplot2::theme(legend.position = "top"),
+	                "bottom.out"   = plot + ggplot2::theme(legend.position = "bottom"),
+	                "none"         = plot + ggplot2::theme(legend.position = "none"),
+	                plot
+	 )
 
 	  # putting colors in
 	  if(cb == TRUE){


### PR DESCRIPTION
Same fix than in  [yesterday's PR](https://github.com/daniel1noble/orchaRd/pull/66), but now in `orchard_plot()`: 

Numeric values for `legend.position` were [deprecated in ggplot2 3.5.0](https://github.com/tidyverse/ggplot2/blob/b87a6e354d19fef05e6d20a24e7b62482ac80b5a/R/theme.R#L534C1-L541C4). Changed it to `legend.position = inside` and used `legend.justification` to define the position.

