### PR TITLE
Clean code and fix typo in mod_results()

### DIFF
--- a/R/mod_results.R
+++ b/R/mod_results.R
@@ -427,15 +427,16 @@ weighted_var <- function(x, weights){
 #' num_studies(model$data, experimental_design, group_ID)
 #' }
 
-num_studies <- function(data, mod, group) {
+num_studies <- function(data, mod, group){
+
   # Summarize the number of studies within each level of moderator
-  table <- data |>
-    dplyr::group_by({{mod}}) |>
-    dplyr::summarise(stdy = length(unique({{group}})))
+   table <- data        %>%
+            dplyr::group_by({{mod}}) %>%
+            dplyr::summarise(stdy = length(unique({{group}})))
 
-  table <- table[!is.na(table$moderator), ]
+   table <- table[!is.na(table$moderator),]
   # Rename, and return
-  colnames(table) <- c("Parameter", "Num_Studies")
+    colnames(table) <- c("Parameter", "Num_Studies")
+      return(data.frame(table))
 
-  return(data.frame(table))
 }


### PR DESCRIPTION
Removed repetitions by moving some assignments out of the if-else block. The logic remains the same, but I think that now it is easier to follow.

Also fixed a typo in `weighted_var()`, line 216: the first argument was _gamma_, but the variable assigned in line 210 was _gamma**s**_. 