### PR TITLE
Bug fix in 'group' validation in mod_results

### DIFF
--- a/R/mod_results.R
+++ b/R/mod_results.R
@@ -556,9 +556,11 @@ group_is_valid <- function(model, group) {
          call. = FALSE)
   }
 
-  # Check that 'group' is not a continuous variable
+  # Check that 'group' is not a continuous variable, but don't stop if it is.
+  # It is not rare to use ID numbers as grouping variables and sometimes they are 'numeric'
+  # instead of 'factor' or 'character'.
   if (is.double(model$data[[group]])) {
-    stop(sprintf("Incorrect argument 'group'. '%s' is a numeric continuous variable, it can't be used for grouping.", group),
+    warning(sprintf("Group '%s' is a numeric variable.", group),
          call. = FALSE)
   }
    


### PR DESCRIPTION
Fix a bug that I introduced while validating inputs (sorry about that). The previous function checked if the `group` column was a continuous variable and stopped if it was. However, I found this problematic when using a column with ID numbers as `group`, which is very common, because R treats them as 'numeric'.

Changed the validation to throw a warning instead of stopping the function.