### PR TITLE
Fix bug using transfm with moderators in orchard_plot

### DIFF
--- a/R/orchard_plot.R
+++ b/R/orchard_plot.R
@@ -122,14 +122,11 @@ orchard_plot <- function(object, mod = "1", group, xlab, N = NULL,
 
   # Transform data if needed
   if (transfm != "none") {
-	numeric_cols <- sapply(mod_table, is.numeric)
-	if(mod != "1"){
-        mod_table[, numeric_cols] <- transform_data(mod_table[, numeric_cols], n = n_transfm, transfm = transfm) # Need this for moderators. TODO: Freeman-Tukey transformation will not work with moderators NEED TO FIX. This is a PATCH L77-85
-    } else{ 
-      mod_table[, numeric_cols] <- transform_data(as.numeric(mod_table[, numeric_cols]), n = n_transfm, transfm = transfm) # Only works for the intercept but generalised to back transform using freeman-tukey 
-                    
-    }
-                 data_trim$yi <- transform_data(data_trim$yi, n = n_transfm, transfm = transfm)
+    numeric_cols <- c("estimate", "lowerCL", "upperCL", "lowerPR", "upperPR")
+    mod_table[, numeric_cols] <- transform_data(mod_table[, numeric_cols], 
+						n = n_transfm,
+						transfm = transfm)
+    data_trim$yi <- transform_data(data_trim$yi, n = n_transfm, transfm = transfm)
   }
 
 	# Add in total effect sizes for each level


### PR DESCRIPTION
Fix #76 

Removed an unnecessary call to `as.numeric()` and changed the if-else statement to make it more general.

The problem was that `as.numeric()` only worked with intercept-only models. However, the user could pass the output from `mod_results()` that used a moderator but without passing a `mod` argument to `orchard_plot()`. In those cases, there was a moderator but the if-else statement could not detect it.