### PR TITLE
Fix #83 - Allow to remove prediction interval

### DIFF
--- a/R/orchard_plot.R
+++ b/R/orchard_plot.R
@@ -209,6 +209,9 @@ orchard_plot <- function(
 #'
 #' @keywords internal
 .orcd_pred_intervals <- function(mod_table, trunk.size, twig.size) {
+  if (twig.size == "none" || twig.size == 0)
+    return(ggplot2::geom_blank())
+
   ggplot2::geom_linerange(
     data = mod_table,
     ggplot2::aes(y = estimate, x = name, min = lowerPR, max = upperPR),


### PR DESCRIPTION
Fix for #83 
Add option to remove prediction intervals by setting `twig.size = 0` or `twig.size = "none"`.