### PR TITLE
Fix problematic subsetting in .run_leave1out

### DIFF
--- a/R/leave_one_out.R
+++ b/R/leave_one_out.R
@@ -141,7 +141,7 @@ leave_one_out <- function(model, group, vcalc_args = NULL, robust_args = NULL, p
     # and change de VCV and phylo matrix if needed. Then evaluate the new call.
 
     tmp_model_call <- model$call
-    tmp_model_call$data <- subset(model$data, model$data[[group]] != id_left_out)
+    tmp_model_call$data <- model$data[model$data[[group]] != id_left_out, ]
 
     # If vcalc_args are provided, create a temporary VCV matrix
     if (!is.null(vcalc_args)) {


### PR DESCRIPTION
In certain cases, subsetting the data inside .run_leave1out would fail with the following (cryptic) error:

```r
Error in .subset2(x, i, exact = exact): 
  attempt to select less than one element in get1index <real>
```

I changed the way subsetting was done and now it works.

Thanks to Javier Oltra Cucarella for reporting the issue and kindly sharing everything needed to reproduce the error!

