### PR TITLE
Fix #87 and other minor changes in tests because of ggplot 4.0 release

### DIFF
--- a/R/orchard_plot.R
+++ b/R/orchard_plot.R
@@ -123,7 +123,7 @@ orchard_plot <- function(
     .orcd_theme(angle) +
     .orcd_reference_line(alpha, refline.pos) +
     .orcd_conf_intervals(mod_table, branch.size) +
-    .orcd_pred_intervals(mod_table, trunk.size, twig.size) +
+    .orcd_pred_intervals(mod_table, twig.size) +
     .orcd_point_estimates(mod_table, colour, trunk.size) +
     .orcd_legends(legend.pos, scale_legend, condition.lab) +
     .orcd_axis_labels(xlab) +
@@ -200,7 +200,7 @@ orchard_plot <- function(
     data = mod_table,
     ggplot2::aes(x = name, ymin = lowerCL, ymax = upperCL),
     position = ggplot2::position_dodge2(width = .set_width(mod_table)),
-    size = branch.size
+    linewidth = branch.size
   )
 }
 
@@ -208,7 +208,7 @@ orchard_plot <- function(
 #' Add prediction intervals
 #'
 #' @keywords internal
-.orcd_pred_intervals <- function(mod_table, trunk.size, twig.size) {
+.orcd_pred_intervals <- function(mod_table, twig.size) {
   if (twig.size == "none" || twig.size == 0)
     return(ggplot2::geom_blank())
 
@@ -216,7 +216,6 @@ orchard_plot <- function(
     data = mod_table,
     ggplot2::aes(y = estimate, x = name, min = lowerPR, max = upperPR),
     position = ggplot2::position_dodge2(width = .set_width(mod_table)),
-    size = trunk.size,
     linewidth = twig.size
   )
 }

--- a/man/dot-orcd_pred_intervals.Rd
+++ b/man/dot-orcd_pred_intervals.Rd
@@ -4,7 +4,7 @@
 \alias{.orcd_pred_intervals}
 \title{Add prediction intervals}
 \usage{
-.orcd_pred_intervals(mod_table, trunk.size, twig.size)
+.orcd_pred_intervals(mod_table, twig.size)
 }
 \description{
 Add prediction intervals

--- a/tests/testthat/test-bubble_plot.R
+++ b/tests/testthat/test-bubble_plot.R
@@ -25,7 +25,7 @@ testthat::test_that("Checking bubble_plot output ...", {
     info = "Check label of x-axis is correctly renamed...")
 
   testthat::expect_equal(
-    plot1$labels$fill, "condition",
+    ggplot2::get_labs(plot1)$fill, "condition",
     info = "Check that condition variable is present in fill...")
 
   testthat::expect_error(orchaRd::bubble_plot(test, mod = "year", legend.pos = "top.left", angle = 45))

--- a/tests/testthat/test-orchard_plot.R
+++ b/tests/testthat/test-orchard_plot.R
@@ -18,11 +18,11 @@ plot2 <- orchard_plot(eklof_MR, xlab = "Grazing", group = "Grazer.type", angle =
 testthat::test_that("Checking orchard_plot output ...", {
 
   testthat::expect_equal(
-    plot1$labels$y, "Grazing",
+    ggplot2::get_labs(plot1)$y, "Grazing",
     info = "xlab for eklof is correct...")
 
   testthat::expect_equal(
-    plot1$labels$ymin, "lowerCL",
+    ggplot2::get_labs(plot1)$ymin, "lowerCL",
     info = "Check that ymin is 'lowerCL' for eklof...")
 
   testthat::expect_equal(


### PR DESCRIPTION
Hello Dan,
Just a few changes.

Fixed #87 : Changed the `geom_linerange()` aesthetic from `size` to `linewidth`.

Also, adjusted `test-orchard_plot` and `test-bubble_plot` because attribute access changed in [ggplot2 4.0](https://tidyverse.org/blog/2025/09/ggplot2-4-0-0/).

Best,
Facundo