### PR TITLE
Fix deprecation of geom_errorbarh() in caterpillars()

### DIFF
--- a/R/caterpillars.R
+++ b/R/caterpillars.R
@@ -113,8 +113,8 @@ caterpillars <- function(object, mod = "1",  group, xlab, overall = TRUE, transf
   # make caterpillars plot
   plot <- ggplot2::ggplot(data = data, ggplot2::aes(x = yi, y = Y)) +
     # 95 % CI
-    ggplot2::geom_errorbarh(ggplot2::aes(xmin = lower, xmax = upper),
-                            colour = colerrorbar, height = 0, show.legend = FALSE, linewidth = 0.5, alpha = 0.6) +
+    ggplot2::geom_errorbar(ggplot2::aes(xmin = lower, xmax = upper),
+                           orientation = "y", colour = colerrorbar, height = 0, show.legend = FALSE, linewidth = 0.5, alpha = 0.6) +
     ggplot2::geom_vline(xintercept = 0, linetype = 2, colour = "black", alpha = 0.5) +
     # creating dots for point estimates
     ggplot2::geom_point(colour = colpoint, size = 1) +


### PR DESCRIPTION
Replace deprecated `geom_errorbarh()` in `caterpillars()` with `geom_errorbar(orientation = "y")` to silence ggplot2 4.0.0 warning.

Best,
Facundo